### PR TITLE
Closing the curl handle on destruction, if set

### DIFF
--- a/lib/Everyman/Neo4j/Transport.php
+++ b/lib/Everyman/Neo4j/Transport.php
@@ -35,6 +35,13 @@ class Transport
 		$this->host = $host;
 		$this->port = $port;
 	}
+	
+	public function __destruct()
+	{
+		if($this->handle) {
+			curl_close($this->handle);
+		}
+	}
 
 	/**
 	 * Return the Neo4j REST endpoint


### PR DESCRIPTION
The curl handle opened by Transport::getHandle() stays open until the script terminates. Added a destructor which closes it when the Transport object is destroyed.
