### PR TITLE
bugfix: Iterating a Row stopped when content was NULL

### DIFF
--- a/lib/Everyman/Neo4j/Query/Row.php
+++ b/lib/Everyman/Neo4j/Query/Row.php
@@ -104,6 +104,6 @@ class Row implements \Iterator, \Countable, \ArrayAccess
 
 	public function valid()
 	{
-		return isset($this->raw[$this->position]);
+		return $this->position < count($this->raw);
 	}
 }

--- a/tests/unit/lib/Everyman/Neo4j/Query/RowTest.php
+++ b/tests/unit/lib/Everyman/Neo4j/Query/RowTest.php
@@ -36,7 +36,22 @@ class RowTest extends \PHPUnit_Framework_TestCase
 			$i++;
 		}
 	}
-	
+
+	public function testIterateWithNull()
+	{
+		$columns = array('name', 'undefined content', 'age');
+		$data = array('Brenda', NULL, 14);
+
+		$row = new Row($this->client, $columns, $data);
+		$i = 0;
+		foreach($row as $columnName => $fieldValue) {
+			$this->assertEquals($columns[$i], $columnName);
+			$this->assertEquals($data[$i], $fieldValue);
+			$i++;
+		}
+		$this->assertEquals(count($columns), $i, 'did not iterate over all data');
+	}
+
 	public function testArrayAccess()
 	{
 		$columns = array('name','age');


### PR DESCRIPTION
Hi,
we discovered a bug when the content of the Everyman\Neo4j\Query\Row class was NULL. In that case, the iterator (like foreach) stopped and did not iterate over all data. NULL should also be a valid content and the iteration must continue until the end, that means the size of the $raw data array.
