### PR TITLE
Unnecessary caching of client object when an entity is cached

### DIFF
--- a/lib/Everyman/Neo4j/PropertyContainer.php
+++ b/lib/Everyman/Neo4j/PropertyContainer.php
@@ -42,6 +42,11 @@ abstract class PropertyContainer
 	{
 		return array_key_exists($key, $this->properties);
 	}
+	
+	public function __sleep()
+	{
+		return array('id', 'properties', 'lazyLoad', 'loaded');
+	}
 
 	/**
 	 * Delete this entity


### PR DESCRIPTION
The client property of an entity doesn't need to be cached, it is injected when an entity is retrieved from the cache.
