### PR TITLE
Cleant::hasBatch method added

### DIFF
--- a/lib/Everyman/Neo4j/Client.php
+++ b/lib/Everyman/Neo4j/Client.php
@@ -629,6 +629,16 @@ class Client
 	}
 
 	/**
+	 * Returns whether the batch is started in Client
+	 *
+	 * @return boolean
+	 */
+	public function hasBatch()
+	{
+		return (bool)$this->openBatch;
+	}
+
+	/**
 	 * Start an implicit batch
 	 *
 	 * Any data manipulation calls that occur between this call


### PR DESCRIPTION
Method is needed if we want to check if batch is already started. It wasn't possible (externally).
