### PR TITLE
Missing use statement for class Exception.

### DIFF
--- a/lib/Everyman/Neo4j/Transport/Curl.php
+++ b/lib/Everyman/Neo4j/Transport/Curl.php
@@ -1,7 +1,8 @@
 <?php
 namespace Everyman\Neo4j\Transport;
 use Everyman\Neo4j\Transport as BaseTransport,
-	Everyman\Neo4j\Version;
+	Everyman\Neo4j\Version,
+	Everyman\Neo4j\Exception;
 
 /**
  * Class for communicating with an HTTP JSON endpoint


### PR DESCRIPTION
The exception is thrown when cURL is not installed. But the exception lives in a different namespace. Alternatively use \exception on line 20.
