### PR TITLE
Improved cURL transport

### DIFF
--- a/lib/Everyman/Neo4j/Transport/Curl.php
+++ b/lib/Everyman/Neo4j/Transport/Curl.php
@@ -51,6 +51,7 @@ class Curl extends BaseTransport
 			CURLOPT_CUSTOMREQUEST => self::GET,
 			CURLOPT_POST => false,
 			CURLOPT_POSTFIELDS => null,
+			CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4,
 		);
 
 		if ($this->username && $this->password) {


### PR DESCRIPTION
Tested on:
Windows 7 64bits
Apache 2.4.6 64-bits
php 5.5.4 64-bits
neo4j Community 2.0.0 Milestone 5

Everything was running on localhost. Default settings for Neo4j server. Less then 10 nodes in database. Transfers were incredibly slow 1 or 2 seconds. While Neo4j web admin and direct curl console commands showed speeds like 20ms. Turned out that php curl first looks for IPv6. Disabling this search significantly speeds up database access (15~20ms now). Source: http://stackoverflow.com/a/11146481
