### PR TITLE
Improved REST performance with HTTP Streaming

### DIFF
--- a/lib/Everyman/Neo4j/Transport/Curl.php
+++ b/lib/Everyman/Neo4j/Transport/Curl.php
@@ -44,7 +44,7 @@ class Curl extends BaseTransport
 			CURLOPT_RETURNTRANSFER => true,
 			CURLOPT_HEADER => true,
 			CURLOPT_HTTPHEADER => array(
-				'Accept: application/json',
+				'Accept: application/json;stream=true',
 				'Content-type: application/json',
 				'User-Agent: '.Version::userAgent(),
 			),


### PR DESCRIPTION
According to this blog http://blog.neo4j.org/2012/04/streaming-rest-api-interview-with.html the performance increases when http streaming is enabled. I tested a query and everything still seems to be functional. However i don't have a large enough graph to really test performance with this at the moment.

Documentation: http://docs.neo4j.org/chunked/snapshot/rest-api-streaming.html
