### PR TITLE
don't load the relationship when it's only traversed

### DIFF
--- a/lib/Everyman/Neo4j/Relationship.php
+++ b/lib/Everyman/Neo4j/Relationship.php
@@ -61,10 +61,9 @@ class Relationship extends PropertyContainer
 	 */
 	public function getEndNode()
 	{
-        if (null === $this->end) {
-            $this->loadProperties();
-        }
-        
+		if (null === $this->end) {
+			$this->loadProperties();
+		}
 		return $this->end;
 	}
 
@@ -75,10 +74,9 @@ class Relationship extends PropertyContainer
 	 */
 	public function getStartNode()
 	{
-        if (null === $this->start) {
-            $this->loadProperties();
-        }
-
+		if (null === $this->start) {
+			$this->loadProperties();
+		}
 		return $this->start;
 	}
 


### PR DESCRIPTION
I was wondering why are the relationship's properties hydrated when only the start and end nodes of it are requested, seems unnecessary to me.
