### PR TITLE
Process errors in batch streaming

### DIFF
--- a/lib/Everyman/Neo4j/Command/Batch/Command.php
+++ b/lib/Everyman/Neo4j/Command/Batch/Command.php
@@ -80,6 +80,7 @@ abstract class Command extends SingleCommand
 		if (isset($result['location'])) {
 			$headers['Location'] = $result['location'];
 		}
-		return $this->base->handleResult(200, $headers, $result);
+		$resultCode = isset($result['status']) ? $result['status'] : 200;
+		return $this->base->handleResult($resultCode, $headers, $result);
 	}
 }


### PR DESCRIPTION
Using streams and batches at the same time changes their behaviour a bit. The [batch returned](http://docs.neo4j.org/chunked/stable/rest-api-batch-ops.html#rest-api-execute-multiple-operations-in-batch-streaming) will contain a `status` key for the individual operations and the status code of the response will be 200. This results in errors being hidden while transactions fail.

If it is not a streamed batch the overall status code of the request should work as was expected before and the individual operations should not have codes of their own, that's why it uses 200 (as it did before) on missing `status`es.
