### PR TITLE
Changed is_numeric to is_int

### DIFF
--- a/lib/Everyman/Neo4j/Command/GetNodesForLabel.php
+++ b/lib/Everyman/Neo4j/Command/GetNodesForLabel.php
@@ -71,7 +71,7 @@ class GetNodesForLabel extends Command
 
 			$propertyName = rawurlencode($this->propertyName);
 
-			if (is_numeric($this->propertyValue)) {
+			if (is_int($this->propertyValue)) {
 				$propertyValue = rawurlencode($this->propertyValue);
 			} else {
 				$propertyValue = rawurlencode('"'.$this->propertyValue.'"');


### PR DESCRIPTION
Only identify explicit integer type variables, not integer strings
