### PR TITLE
added neo4j service for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ before_script:
     - composer install --dev
 
 script: ./vendor/bin/phing ci
+
+services:
+	- neo4j


### PR DESCRIPTION
This adds the Neo4j service to Travis builds.

This can help write tests against a real database and prove stability for real use cases when reviewing PR's .