### PR TITLE
Issue #136: Wrong data value returned in Row in case of non-existent index

### DIFF
--- a/lib/Everyman/Neo4j/Query/Row.php
+++ b/lib/Everyman/Neo4j/Query/Row.php
@@ -56,6 +56,10 @@ class Row implements \Iterator, \Countable, \ArrayAccess
 			$offset = array_search($offset, $this->columns);
 		}
 
+		if ($offset === false) {
+			return false;
+		}
+
 		if (!isset($this->data[$offset])) {
 			$raw = $this->raw[$offset];
 			$data = $this->client->getEntityMapper()->getEntityFor($raw);

--- a/tests/unit/lib/Everyman/Neo4j/Query/RowTest.php
+++ b/tests/unit/lib/Everyman/Neo4j/Query/RowTest.php
@@ -69,6 +69,9 @@ class RowTest extends \PHPUnit_Framework_TestCase
 		
 		$this->assertEquals(false, isset($row['blah']));
 		$this->assertEquals(false, isset($row[3]));
+
+		// Prevent regression of #136
+		$this->assertFalse($row['long and non-existing key']);
 	}
 
 	public function testArrayAccess_Set_ThrowsException()


### PR DESCRIPTION
When using a non-existing array offset to get from the Row, array_search will return false. This will be typecasted into a int and offset 0 will be returned instead of the requested.

This fixes so if array_search() returns false, offsetGet() also returns false.

The existing testcases did not detect this bug since they used isset() for the non-existing keys, resulting in the usage of offsetExists(), not offsetGet().
