### PR TITLE
Create addLabel method for Node class

### DIFF
--- a/lib/Everyman/Neo4j/Node.php
+++ b/lib/Everyman/Neo4j/Node.php
@@ -44,6 +44,18 @@ class Node extends PropertyContainer
 	}
 
 	/**
+	* Add label to this node
+	*
+	* @param Label $label
+	* @return array of all the Labels on this node, including those just added
+	*/
+	public function addLabel($label)
+	{
+		$labels = array($label);
+		return $this->addLabels($labels);
+	}
+
+	/**
 	 * Delete this node
 	 *
 	 * @return PropertyContainer

--- a/lib/Everyman/Neo4j/Node.php
+++ b/lib/Everyman/Neo4j/Node.php
@@ -49,7 +49,7 @@ class Node extends PropertyContainer
 	* @param Label $label
 	* @return array of all the Labels on this node, including those just added
 	*/
-	public function addLabel($label)
+	public function addLabel(Label $label)
 	{
 		$labels = array($label);
 		return $this->addLabels($labels);

--- a/tests/unit/lib/Everyman/Neo4j/NodeTest.php
+++ b/tests/unit/lib/Everyman/Neo4j/NodeTest.php
@@ -81,6 +81,28 @@ class NodeTest extends \PHPUnit_Framework_TestCase
 		$this->assertSame($label, $labels[0]);
 	}
 
+	public function testAddLabel_DelegatesToClient()
+	{
+		$expected = $this->node;
+		$expected->setId(123);
+		$matched = false;
+		
+		$label = new Label($this->client, 'FOOBAR');
+		
+		$this->client->expects($this->once())
+			->method('addLabels')
+			// Have to do it this way because PHPUnit clones object parameters
+			->will($this->returnCallback(function (Node $actual, $labels) use ($expected, $label, &$matched) {
+				$matched = $expected->getId() == $actual->getId();
+				$matched = $matched && $label->getName() == $labels[0]->getName();
+				return array($label);
+			}));
+
+		$labels = $this->node->addLabel($label);
+		$this->assertEquals(1, count($labels));
+		$this->assertSame($label, $labels[0]);
+	}
+
 	public function testRemoveLabels_DelegatesToClient()
 	{
 		$expected = $this->node;


### PR DESCRIPTION
Occasionally you need to add a single `Label` to a `Node` and it is clumsy to do so by first creating a new `array`.

I am proposing a new method on the `Node` class to allow addition of a single `Label` to a `Node`. 

This method centralizes the creation of an `array` with the provided `Label`, passes it directly to the `addLabels` method, and returns the list of all `Node` `Labels`.

```php
public function addLabel(Label $label)
{
        $labels = array($label);
        return $this->addLabels($labels);
}
```