### PR TITLE
Create removeLabel method for Node class

### DIFF
--- a/lib/Everyman/Neo4j/Node.php
+++ b/lib/Everyman/Neo4j/Node.php
@@ -163,6 +163,18 @@ class Node extends PropertyContainer
 	}
 
 	/**
+	 * Remove label from this node
+	 *
+	 * @param Label $label
+	 * @return array of all the Labels on this node, after removing the given label
+	 */
+	public function removeLabel(Label $label)
+	{
+		$labels = array($label);
+		return $this->removeLabels($labels);
+	}
+
+	/**
 	 * Save this node
 	 *
 	 * @return PropertyContainer

--- a/tests/unit/lib/Everyman/Neo4j/NodeTest.php
+++ b/tests/unit/lib/Everyman/Neo4j/NodeTest.php
@@ -103,6 +103,28 @@ class NodeTest extends \PHPUnit_Framework_TestCase
 		$this->assertSame($label, $labels[0]);
 	}
 
+	public function testRemoveLabel_DelegatesToClient()
+	{
+		$expected = $this->node;
+		$expected->setId(123);
+		$matched = false;
+
+		$label = new Label($this->client, 'FOOBAR');
+
+		$this->client->expects($this->once())
+			->method('removeLabels')
+			// Have to do it this way because PHPUnit clones object parameters
+			->will($this->returnCallback(function (Node $actual, $labels) use ($expected, $label, &$matched) {
+				$matched = $expected->getId() == $actual->getId();
+				$matched = $matched && $label->getName() == $labels[0]->getName();
+				return array($label);
+			}));
+
+		$labels = $this->node->removeLabel($label);
+		$this->assertEquals(1, count($labels));
+		$this->assertSame($label, $labels[0]);
+	}
+
 	/**
 	 * Test for https://github.com/jadell/neo4jphp/issues/58
 	 */


### PR DESCRIPTION
Similar to #166, occasionally you need to remove a single `Label` from a `Node` and it is clumsy to do so by first creating a new `array`.

I am proposing a new method on the `Node` class to allow removal of a single `Label` from a `Node`. 

This method centralizes the creation of an `array` with the provided `Label`, passes it directly to the `removeLabels` method, and returns the list of all `Node` `Labels`.

```php
public function removeLabel(Label $label)
{
        $labels = array($label);
        return $this->removeLabels($labels);
}
```