### PR TITLE
Skip memcached tests if using an incompatible version of memcached.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.5
 
 before_script:
+    - pecl install -f memcached-2.1.0
     - phpenv config-add phpconfig.ini
     - composer install --dev
 

--- a/tests/unit/lib/Everyman/Neo4j/Cache/MemcachedTest.php
+++ b/tests/unit/lib/Everyman/Neo4j/Cache/MemcachedTest.php
@@ -8,8 +8,11 @@ class MemcachedTest extends \PHPUnit_Framework_TestCase
 
 	public function setUp()
 	{
-		if (!phpversion('memcached')) {
+		$memcachedVersion = phpversion('memcached');
+		if (!$memcachedVersion) {
 			$this->markTestSkipped('Memcached extension not enabled/installed');
+		} else if (version_compare($memcachedVersion, '2.2.0', '>=')) {
+			$this->markTestSkipped('Memcached tests can only be run with memcached extension 2.1.0 or lower');
 		}
 
 		$this->memcached = $this->getMock('\Memcached');


### PR DESCRIPTION
Remove the "skip" and "pecl install" changes once php-memcached-dev/php-memcached#126 has been resolved.