### PR TITLE
PHP7 Compatibility

### DIFF
--- a/lib/Everyman/Neo4j/Cache/BlackHole.php
+++ b/lib/Everyman/Neo4j/Cache/BlackHole.php
@@ -6,7 +6,7 @@ use Everyman\Neo4j\Cache;
 /**
  * Cache that always indicates success but does not store anything
  */
-class Null implements Cache
+class BlackHole implements Cache
 {
 	/**
 	 * Delete always succeeds

--- a/lib/Everyman/Neo4j/Cache/EntityCache.php
+++ b/lib/Everyman/Neo4j/Cache/EntityCache.php
@@ -89,7 +89,7 @@ class EntityCache
 	protected function getCache()
 	{
 		if ($this->cache === null) {
-			$this->setCache(new Cache\Null(), $this->cacheTimeout);
+			$this->setCache(new Cache\BlackHole(), $this->cacheTimeout);
 		}
 		return $this->cache;
 	}

--- a/tests/unit/lib/Everyman/Neo4j/Cache/NullTest.php
+++ b/tests/unit/lib/Everyman/Neo4j/Cache/NullTest.php
@@ -1,13 +1,13 @@
 <?php
 namespace Everyman\Neo4j\Cache;
 
-class NullTest extends \PHPUnit_Framework_TestCase
+class BlackHoleTest extends \PHPUnit_Framework_TestCase
 {
 	protected $cache = null;
 
 	public function setUp()
 	{
-		$this->cache = new Null();
+		$this->cache = new BlackHole();
 	}
 
 	public function testDelete_ReturnsTrue()


### PR DESCRIPTION
Since `Null` class name is not allowed anymore in PHP7, `Cache\Null` has to be refactored with a new name.

I chose `Cache\BlackHole`, since it is an alternative name to the `Null` kind of class that do no real operations.