### PR TITLE
Fix array json encoding for float values.

### DIFF
--- a/lib/Everyman/Neo4j/Transport.php
+++ b/lib/Everyman/Neo4j/Transport.php
@@ -65,7 +65,7 @@ abstract class Transport
 			}
 		}
 
-		$encoded = json_encode($data);
+		$encoded = json_encode($data, JSON_PRESERVE_ZERO_FRACTION);
 		return $encoded;
 	}
 


### PR DESCRIPTION
There is a bug when json encoding float values inside array:
Ex "bbox":[-66.11667,-11,-66.11667,-11]
ex -11 -> -11 but in order to accomplish to https://neo4j.com/docs/rest-docs/current/#_arrays we need to have -11.0 to avoid Invalid JSON array in POST body error. It's enough add JSON_PRESERVE_ZERO_FRACTION to inside json_encode call.
This is mandatory to use spatial plugin with rest.